### PR TITLE
Comment out GroupDelegate tests causing segfaults

### DIFF
--- a/tournament_services/tests/delegate/GroupDelegateTest.cpp
+++ b/tournament_services/tests/delegate/GroupDelegateTest.cpp
@@ -82,3 +82,6 @@ protected:
 
 // All 12 GroupDelegate tests commented out - they cause segfaults in Release builds
 */
+
+/* Posible solución: usar una interfaz para pura para mockear o clases abstractas con métodos virtuales puros
+El mock  hereda directamente de la interfaz, sin necesidad de llamar al constructor de la clase concreta que requiere el nullptr de la dependencia.*/


### PR DESCRIPTION
Comment out all GroupDelegate tests due to segfaults in Release builds and suggest using interfaces for mocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Internal test documentation updates with proposed solutions for testing patterns.

**Note:** No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->